### PR TITLE
Allow clearing volume and reinitializing with new parameters

### DIFF
--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -82,6 +82,7 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          include
          ${ROS_INCLUDE_DIRS}
          ${OpenCV_INCLUDE_DIRS}
+         ${PCL_INCLUDE_DIRS}
          ${CUDA_INCLUDE_DIRS}
          ${Eigen_INCLUDE_DIRS}
        LIBRARIES
@@ -106,6 +107,7 @@ else()
 
     ament_export_include_directories(include
                                     ${OpenCV_INCLUDE_DIRS}
+                                    ${PCL_INCLUDE_DIRS}
                                     ${CUDA_INCLUDE_DIRS}
                                     ${Eigen_INCLUDE_DIRS}
                                     )

--- a/yak/include/yak/kfusion/kinfu.hpp
+++ b/yak/include/yak/kfusion/kinfu.hpp
@@ -4,6 +4,8 @@
 #include "yak/kfusion/types.hpp"
 #include "yak/kfusion/cuda/tsdf_volume.hpp"
 #include "yak/kfusion/cuda/projective_icp.hpp"
+#include <Eigen/Core>
+#include <Eigen/StdVector>
 #include <vector>
 #include <string>
 
@@ -55,7 +57,7 @@ namespace kfusion
             bool use_pose_hints;
             bool use_icp;
             bool update_via_sensor_motion;
-
+            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 
     class KF_EXPORTS KinFu
@@ -92,7 +94,7 @@ namespace kfusion
             KinFuParams params_;
 
             // Sensor pose, currenly calculated  via ICP
-            std::vector<Affine3f> poses_;
+            std::vector<Affine3f, Eigen::aligned_allocator<Affine3f>> poses_;
 
             cuda::Dists dists_;
             cuda::Frame curr_, prev_;
@@ -103,6 +105,8 @@ namespace kfusion
 
             cv::Ptr<cuda::TsdfVolume> volume_;
             cv::Ptr<cuda::ProjectiveICP> icp_;
+        public:
+            EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     };
 }
 #endif

--- a/yak/include/yak/kfusion/tsdf_container.h
+++ b/yak/include/yak/kfusion/tsdf_container.h
@@ -52,9 +52,11 @@ private:
     std::memcpy(&weight, ((char*)(&data)) + 2, 2);
   }
 
-private:
   std::shared_ptr<std::vector<uint32_t>> data_;
   Eigen::Vector3i dims_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 }

--- a/yak/include/yak/yak_server.h
+++ b/yak/include/yak/yak_server.h
@@ -37,6 +37,10 @@ public:
 
   yak::TSDFContainer downloadTSDF();
 
+  void display();
+
+  void display(const Eigen::Affine3f& pose);
+
 private:
   bool step(const Eigen::Affine3f& current_pose, const Eigen::Affine3f& last_pose, const cv::Mat& depth);
 
@@ -45,18 +49,15 @@ private:
    */
   void downloadAndDisplayView();
 
-public:
-  void display();
-  void display(const Eigen::Affine3f& pose);
-
-
-private:
   kfusion::KinFu::Ptr kinfu_;
   kfusion::cuda::Image viewDevice_;
   kfusion::cuda::Depth depthDevice_;
 
   Eigen::Affine3f volume_to_world_;
   Eigen::Affine3f last_camera_pose_;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 } /* namespace yak */

--- a/yak/include/yak/yak_server.h
+++ b/yak/include/yak/yak_server.h
@@ -29,6 +29,10 @@ public:
 
   bool fuse(const cv::Mat& depth_data, const Eigen::Affine3f& world_to_camera);
 
+  bool reset();
+
+  bool resetWithNewParams(const kfusion::KinFuParams& params);
+
 //  void getCloud(pcl::PointCloud<pcl::PointXYZ>& cloud) const;
 
   yak::TSDFContainer downloadTSDF();

--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -10,8 +10,8 @@ namespace
 
 struct Triangle
 {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   Eigen::Vector3f v[3];
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 float getOffset(float value1, float value2, float value_desired)

--- a/yak/src/mc/marching_cubes_tests.cpp
+++ b/yak/src/mc/marching_cubes_tests.cpp
@@ -74,8 +74,8 @@ std::unique_ptr<Grid> makeScene2()
 
 struct Triangle
 {
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   Eigen::Vector3f v[3];
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
 float getOffset(float value1, float value2, float value_desired)

--- a/yak/src/yak_server.cpp
+++ b/yak/src/yak_server.cpp
@@ -2,7 +2,7 @@
 #include <opencv2/highgui.hpp> // named-window apparatus; TODO: Remove this
 
 yak::FusionServer::FusionServer(const kfusion::KinFuParams& params,
-                                                      const Eigen::Affine3f& world_to_volume)
+                                const Eigen::Affine3f& world_to_volume)
   : kinfu_(new kfusion::KinFu(params))
   , volume_to_world_(world_to_volume.inverse())
   , last_camera_pose_(Eigen::Affine3f::Identity())
@@ -36,6 +36,18 @@ bool yak::FusionServer::fuse(const cv::Mat& depth_data, const Eigen::Affine3f& w
   display();
 
   return result;
+}
+
+bool yak::FusionServer::reset()
+{
+  kinfu_->resetVolume();
+  return true;
+}
+
+bool yak::FusionServer::resetWithNewParams(const kfusion::KinFuParams &params)
+{
+  kinfu_.reset(new kfusion::KinFu(params));
+  return true;
 }
 
 //void yak::FusionServer::getCloud(pcl::PointCloud<pcl::PointXYZ>& cloud) const


### PR DESCRIPTION
Add functions to expose zeroing the contents of all the voxels in the volume and resetting the volume with new parameters.

Also provide fixes for (or at least insurance against) the Eigen array assertion error.