### PR TITLE
Use modern CMake practices and improvements to CUDA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Yak
 
-Yak is a library for integrating depth images into Truncated Signed Distance Fields (TSDFs). An example ROS node using Yak is provided in the [yak_ros](https://github.com/ros-industrial/yak_ros) repository.
+Yak is a library for integrating depth images into Truncated Signed Distance Fields (TSDFs). It is currently supported for Ubuntu 16.04 and Ubuntu 18.04. An example ROS node using Yak is provided in the [yak_ros](https://github.com/ros-industrial/yak_ros) repository.
+
+## Technical Background
 
 A TSDF is a probabilistic representation of a solid surface in 3D space. It's a useful tool for combining many noisy incomplete sensor readings into a single smooth and complete model.
 
@@ -18,9 +20,116 @@ Yak is intended as a flexible library that gives the end user (you!) a lot of fr
 
 ![An aluminum part reconstructed as a TSDF and meshed with the Marching Cubes algorithm.](/aluminum_channel_mesh.png)
 
-# Readme TODOs:
+## Dependencies
 
-- Basic setup instructions
+### CMake
+
+Yak requires CMake 3.10.0 or newer in order to take advantage of improved support for CUDA. If you're using Ubuntu 18.04 or newer you should already have a suitable version. If you're using an older distribution (e.g. 16.04) you will need to install a compatible version of CMake yourself.
+
+1. Install pip (if it isn't already installed):
+```
+sudo apt install python-pip
+```
+
+2. Use pip to install CMake locally, which will not overwrite the system installation of CMake. As of September 5 2019 this installs CMake 3.14.4 on Ubuntu 16.04.
+```
+pip install --user cmake --upgrade
+```
+
+3. (Optional, depending on the specifics of your environment) Prepend the directory where CMake was just installed to the PATH environment variable. You may also add this to `.bashrc`.
+```
+export PATH=:/home/YOUR_USERNAME/.local/bin:$PATH
+```
+
+### CUDA
+
+Yak requires an NVidia GPU and CUDA 9.0 or newer.
+
+1. CUDA depends on Nvidia third-party drivers and will not work with the default Nouveau drivers. Determine which version of the Nvidia driver is compatible with your computer's GPU by running `ubuntu-drivers devices`. Usually the driver version listed as "third-party free recommended" is suitable. You can install the recommended driver using `sudo ubuntu-drivers autoinstall`. Example output listed below:
+
+```
+== /sys/devices/pci0000:00/0000:00:02.0/0000:02:00.0 ==
+modalias : pci:v000010DEd000017C8sv00001458sd000036CBbc03sc00i00
+vendor   : NVIDIA Corporation
+model    : GM200 [GeForce GTX 980 Ti]
+driver   : nvidia-driver-418 - third-party free recommended
+driver   : nvidia-driver-410 - third-party free
+driver   : nvidia-driver-390 - distro non-free
+driver   : xserver-xorg-video-nouveau - distro free builtin
+```
+
+2. Consult the chart below (copied from [here](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver) as of September 5 2019) to find which CUDA version is compatible with the drivers supported by your GPU. Yak is currently not compatible with CUDA <= 8.0.
+
+| CUDA Toolkit | Linux x86_64 Driver Version |
+|---|---|
+| CUDA 10.1 (10.1.105) | >= 418.39 |
+| CUDA 10.0 (10.0.130) | >= 410.48 | 
+| CUDA 9.2 (9.2.88) | >= 396.26 |
+| CUDA 9.1 (9.1.85) | >= 390.46 |
+| CUDA 9.0 (9.0.76) | >= 384.81 |
+| CUDA 8.0 (8.0.61 GA2) | >= 375.26 |
+| CUDA 8.0 (8.0.44) | >= 367.48 | 
+| CUDA 7.5 (7.5.16) | >= 352.31 |
+| CUDA 7.0 (7.0.28) | >= 346.46 |
+
+3. Specific installation instructions vary depending on the combination of Ubuntu version, CUDA version, and Nvidia driver version. Please read the linked instructions carefully: they are very important, and CUDA may not work correctly if you skip a step!
+
+- Package manager installation is usually the easiest method, especially if you have Ubuntu 18.04 and a new GPU. [Download a compatible version of CUDA from here](https://developer.nvidia.com/cuda-toolkit-archive) (pick "Installer Type: deb (network)") and then [follow these instructions](https://docs.nvidia.com/cuda/cuda-quick-start-guide/index.html#ubuntu-x86_64-deb). 
+
+- Nvidia doesn't release debians for every combination of Ubuntu release and CUDA version. If the package manager installation method fails to find a compatible .deb (e.g. you have Ubuntu 18.04 but your GPU only supports driver version 384), [download the runfile version of the CUDA installer from here](https://developer.nvidia.com/cuda-toolkit-archive) (pick "Installer Type: runfile (local)") and then [follow the runfile installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#runfile). Since you have already installed the NVidia driver in step 1 you do not need to reboot your system into non-GUI mode, and when the runfile dialog asks if you would like to install these drivers you may decline.
+
+4. Follow the instructions in [Post-installation Actions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#post-installation-actions). It is not necessary to complete the steps listed under "POWER9 Setup" -- you probably do not have a POWER9-compatible system unless you work with supercomputers.
+
+### OpenMP
+
+Yak required OpenMP for parallelization of the marching cubes surface reconstruction process.
+```
+sudo apt install libomp-dev
+```
+
+### OpenCV
+
+Yak requires OpenCV 3.0 or newer. If you are using ROS then this dependency is already satisfied. Otherwise you will need to install it yourself:
+```
+sudo apt install libopencv-dev
+```
+
+### Eigen
+
+Yak requires Eigen 3. If you are using ROS then this dependency is already satisfied. Otherwise you will need to install it yourself:
+```
+sudo apt install libeigen3-dev
+```
+
+### PCL
+
+Yak requires PCL 1.8 or newer. If you are using ROS then this dependency is already satisfied. Otherwise you will need to install it yourself:
+```
+sudo apt install libpcl-dev
+```
+
+## Installation
+
+### Build with ROS (recommended)
+
+Installing ROS is beyond the scope of this readme. There are installation instructions [here for ROS1](http://wiki.ros.org/melodic/Installation/Ubuntu) and [here for ROS2](https://index.ros.org/doc/ros2/Installation/Dashing/Linux-Install-Debians/).
+
+Clone this package into the `src` directory of a ROS workspace. For ROS1 use `catkin build` to build the workspace. For ROS2 use `colcon build` to build the workspace.
+
+### Build Standalone (in development)
+
+```
+git clone https://github.com/ros-industrial/yak.git
+cd yak
+mkdir build
+cd build
+cmake ../yak
+make
+sudo make install
+```
+
+## Readme TODOs:
+
 - Minimally-functional example
 - Documentation of services, inputs, outputs, etc.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ driver   : xserver-xorg-video-nouveau - distro free builtin
 
 ### OpenMP
 
-Yak required OpenMP for parallelization of the marching cubes surface reconstruction process.
+Yak requires OpenMP for parallelization of the marching cubes surface reconstruction process.
 ```
 sudo apt install libomp-dev
 ```
@@ -115,6 +115,8 @@ sudo apt install libpcl-dev
 Installing ROS is beyond the scope of this readme. There are installation instructions [here for ROS1](http://wiki.ros.org/melodic/Installation/Ubuntu) and [here for ROS2](https://index.ros.org/doc/ros2/Installation/Dashing/Linux-Install-Debians/).
 
 Clone this package into the `src` directory of a ROS workspace. For ROS1 use `catkin build` to build the workspace. For ROS2 use `colcon build` to build the workspace.
+
+Take a look at the [yak_ros](https://github.com/ros-industrial/yak_ros) package for example implementations of ROS nodes using Yak.
 
 ### Build Standalone (in development)
 

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -11,11 +11,22 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
   set(CMAKE_CUDA_STANDARD_REQUIRED True)
 endif()
 
-find_package(OpenMP REQUIRED)
 find_package(CUDA 9.0 REQUIRED)
 find_package(OpenCV 3 REQUIRED COMPONENTS core highgui)
 find_package(Eigen3 REQUIRED)
 find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry)
+
+find_package(OpenMP REQUIRED)
+if(NOT TARGET OpenMP::OpenMP_CXX)
+    find_package(Threads REQUIRED)
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+    # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+endif()
+
 
 # Core CUDA Library for depth image processing
 add_library(${PROJECT_NAME} SHARED

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -1,133 +1,24 @@
-cmake_minimum_required(VERSION 3.5.0)
-project(yak)
+cmake_minimum_required(VERSION 3.10.0)
+project(yak VERSION 0.2.0 LANGUAGES CUDA CXX)
 
-# Default to C++14 for cross-compatibility
-if(NOT CMAKE_CXX_STANDARD)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED True)
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra)
+if(NOT DEFINED CMAKE_CUDA_STANDARD)
+  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD_REQUIRED True)
 endif()
-
-MACRO(CUDA_COMPUTE_TARGET_FLAGS arch_bin arch_ptx cuda_nvcc_target_flags)
-    string(REGEX REPLACE "\\." "" ARCH_BIN_WITHOUT_DOTS "${${arch_bin}}")
-    string(REGEX REPLACE "\\." "" ARCH_PTX_WITHOUT_DOTS "${${arch_ptx}}")
-
-    set(cuda_computer_target_flags_temp "")
-
-    # Tell NVCC to add binaries for the specified GPUs
-    string(REGEX MATCHALL "[0-9()]+" ARCH_LIST "${ARCH_BIN_WITHOUT_DOTS}")
-    foreach(ARCH IN LISTS ARCH_LIST)
-        if (ARCH MATCHES "([0-9]+)\\(([0-9]+)\\)")
-            # User explicitly specified PTX for the concrete BIN
-            set(cuda_computer_target_flags_temp ${cuda_computer_target_flags_temp} -gencode;arch=compute_${CMAKE_MATCH_2},code=sm_${CMAKE_MATCH_1};)
-        else()
-            # User didn't explicitly specify PTX for the concrete BIN, we assume PTX=BIN
-            set(cuda_computer_target_flags_temp ${cuda_computer_target_flags_temp} -gencode;arch=compute_${ARCH},code=sm_${ARCH};)
-        endif()
-    endforeach()
-
-    # Tell NVCC to add PTX intermediate code for the specified architectures
-    string(REGEX MATCHALL "[0-9]+" ARCH_LIST "${ARCH_PTX_WITHOUT_DOTS}")
-    foreach(ARCH IN LISTS ARCH_LIST)
-        set(cuda_computer_target_flags_temp ${cuda_computer_target_flags_temp} -gencode;arch=compute_${ARCH},code=compute_${ARCH};)
-    endforeach()
-
-    set(${cuda_nvcc_target_flags} ${cuda_computer_target_flags_temp})
-ENDMACRO()
-
-MACRO(APPEND_TARGET_ARCH_FLAGS)
-    set(cuda_nvcc_target_flags "")
-    CUDA_COMPUTE_TARGET_FLAGS(CUDA_ARCH_BIN CUDA_ARCH_PTX cuda_nvcc_target_flags)
-    if (cuda_nvcc_target_flags)
-        message(STATUS "CUDA NVCC target flags: ${cuda_nvcc_target_flags}")
-        list(APPEND CUDA_NVCC_FLAGS ${cuda_nvcc_target_flags})
-    endif()
-ENDMACRO()
-
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
-message(STATUS "CMAKE MODULE PATH IS ${CMAKE_MODULE_PATH}")
-
-# TODO: Use built-in CUDA language support from CMake 3.8+ (requires different flags)
-#enable_language(CUDA)
 
 find_package(OpenMP REQUIRED)
-
-find_package(CUDA REQUIRED)
-
-if (CUDA_VERSION_MAJOR GREATER 8)
-    set(CUDA_ARCH_BIN "3.0 5.0 5.2 6.0 6.1" CACHE STRING "Specify 'real' GPU architectures to build binaries for, BIN(PTX) format is supported")
-else()
-    set(CUDA_ARCH_BIN "2.0 2.1 3.0 5.0 5.2 6.0 6.1" CACHE STRING "Specify 'real' GPU architectures to build binaries for, BIN(PTX) format is supported")
-endif()
-APPEND_TARGET_ARCH_FLAGS()
-
-message(STATUS ${CUDA_NVCC_FLAGS})
-
+find_package(CUDA 9.0 REQUIRED)
 find_package(OpenCV 3 REQUIRED COMPONENTS core highgui)
 find_package(Eigen3 REQUIRED)
-find_package(PCL 1.9 REQUIRED COMPONENTS common io geometry)  # need to use PCL 1.9 because there's a GCC flag problem when building with 1.8
-set_directory_properties( PROPERTIES COMPILE_DEFINITIONS "" )
-
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
-if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
-    # Build for ROS 1 using Catkin
-     find_package(catkin)
-
-     catkin_package(
-       INCLUDE_DIRS
-         include
-         ${ROS_INCLUDE_DIRS}
-         ${OpenCV_INCLUDE_DIRS}
-         ${PCL_INCLUDE_DIRS}
-         ${CUDA_INCLUDE_DIRS}
-         ${Eigen_INCLUDE_DIRS}
-       LIBRARIES
-        ${PROJECT_NAME}
-         ${PROJECT_NAME}_frontend
-         ${PROJECT_NAME}_marching_cubes
-         ${CUDA_LIBRARIES}
-         ${CUDA_CUDA_LIBRARY}
-         ${OpenCV_LIBS}
-         ${OpenMP_CXX_LIBRARIES}
-       CATKIN_DEPENDS
-       DEPENDS
-         OpenCV
-         EIGEN3
-         CUDA
-         OpenMP
-         PCL
-   )
-else()
-    # Build for ROS 2 using Ament
-    find_package(ament_cmake REQUIRED)
-
-    ament_export_include_directories(include
-                                    ${OpenCV_INCLUDE_DIRS}
-                                    ${PCL_INCLUDE_DIRS}
-                                    ${CUDA_INCLUDE_DIRS}
-                                    ${Eigen_INCLUDE_DIRS}
-                                    )
-
-    ament_export_libraries(${PROJECT_NAME}
-                           ${PROJECT_NAME}_frontend
-                           ${PROJECT_NAME}_marching_cubes
-                           ${CUDA_LIBRARIES}
-                           ${CUDA_CUDA_LIBRARY}
-                           ${OpenCV_LIBS}
-                           ${OpenMP_CXX_LIBRARIES}
-                           )
-
-    ament_export_dependencies(OpenCV Eigen3 CUDA OpenMP PCL)
-
-    ament_package()
-endif()
+find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry)
 
 # Core CUDA Library for depth image processing
-cuda_add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/kfusion/core.cpp
   src/kfusion/device_memory.cpp
   src/kfusion/imgproc.cpp
@@ -137,95 +28,97 @@ cuda_add_library(${PROJECT_NAME}
   src/kfusion/tsdf_volume.cpp
   src/cuda/imgproc.cu
   src/cuda/proj_icp.cu
-  src/cuda/tsdf_volume.cu
-)
-
+  src/cuda/tsdf_volume.cu)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-  ${CUDA_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   ${OpenCV_INCLUDE_DIRS}
-)
-
-target_link_libraries(${PROJECT_NAME}
+  ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${OpenCV_LIBRARIES}
   ${CUDA_LIBRARIES}
   ${CUDA_CUDA_LIBRARY}
-  ${OpenCV_LIBRARIES}
-  ${PCL_LIBRARIES}
-)
+  Eigen3::Eigen)
+list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME})
 
 # Jmeyer - Create a new interface library that I want to be the front end for future processing. It should support
 # a minimal interface of pushing and image with a pose guess into the server and integrating.
-add_library(${PROJECT_NAME}_frontend
+add_library(${PROJECT_NAME}_frontend SHARED
     src/yak_server.cpp
-    src/kfusion/tsdf_container.cpp
-)
-
+    src/kfusion/tsdf_container.cpp)
 target_include_directories(${PROJECT_NAME}_frontend PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-  ${EIGEN3_INCLUDE_DIR}
-  ${PCL_INCLUDE_DIRS}
-)
-
-target_link_libraries(${PROJECT_NAME}_frontend
- ${PROJECT_NAME}
- ${PCL_LIBRARIES}
-)
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME}_frontend SYSTEM PUBLIC
+  ${PCL_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_frontend PUBLIC
+  ${PROJECT_NAME}
+  ${PCL_LIBRARIES}
+  Eigen3::Eigen)
+list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME}_frontend)
 
 # Marching Cubes Meshing Impl
-add_library(${PROJECT_NAME}_marching_cubes
+add_library(${PROJECT_NAME}_marching_cubes SHARED
   src/mc/marching_cubes.cpp
   src/mc/marching_cubes_tables.cpp)
-
 target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-  ${EIGEN3_INCLUDE_DIR}
-  ${PCL_INCLUDE_DIRS}
-)
-
-target_link_libraries(${PROJECT_NAME}_marching_cubes
-    PUBLIC
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
+  ${PCL_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_marching_cubes PUBLIC
   ${PROJECT_NAME}
+  ${PCL_LIBRARIES}
   OpenMP::OpenMP_CXX
-)
+  Eigen3::Eigen)
+list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME}_marching_cubes)
 
 # Jmeyer Marching Cubes
 add_executable(marching_cubes_tests src/mc/marching_cubes_tests.cpp)
-
 target_include_directories(marching_cubes_tests PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
-  ${EIGEN3_INCLUDE_DIR}
-  ${PCL_INCLUDE_DIRS}
-)
-
+  "$<INSTALL_INTERFACE:include>")
+target_include_directories(marching_cubes_tests SYSTEM PUBLIC
+  ${PCL_INCLUDE_DIRS})
 target_link_libraries(marching_cubes_tests
-    ${PROJECT_NAME}_marching_cubes
-    ${PCL_LIBRARIES}
-)
+  ${PROJECT_NAME}_marching_cubes
+  ${PCL_LIBRARIES}
+  Eigen3::Eigen)
 
-
-if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
-    set(ROS_LIB_DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-    set(ROS_BIN_DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-else()
-    set(ROS_LIB_DESTINATION lib)
-    set(ROS_BIN_DESTINATION bin)
-endif()
-
-set(ROS_INCLUDE_DESTINATION include)
-
-
+# Install project files
 install(DIRECTORY include/${PROJECT_NAME}
-  DESTINATION ${ROS_INCLUDE_DESTINATION}
-)
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+  PATTERN "*.svn" EXCLUDE)
 
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_frontend ${PROJECT_NAME}_marching_cubes
-  ARCHIVE DESTINATION ${ROS_LIB_DESTINATION}
-  LIBRARY DESTINATION ${ROS_LIB_DESTINATION}
-  RUNTIME DESTINATION ${ROS_BIN_DESTINATION}
-  )
+install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+
+install(TARGETS marching_cubes_tests
+        RUNTIME DESTINATION lib)
+
+# Install CMake targets and config files
+install(TARGETS ${PACKAGE_LIBRARIES}
+  EXPORT ${PROJECT_NAME}-targets DESTINATION lib)
+install(EXPORT ${PROJECT_NAME}-targets
+  NAMESPACE yak:: DESTINATION lib/cmake/${PROJECT_NAME})
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+  VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+  DESTINATION lib/cmake/${PROJECT_NAME})
+
+export(EXPORT ${PROJECT_NAME}-targets FILE
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake)
+

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -13,7 +13,6 @@ endif()
 
 find_package(CUDA 9.0 REQUIRED)
 find_package(OpenCV 3 REQUIRED COMPONENTS core highgui)
-find_package(Eigen3 REQUIRED)
 find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry)
 
 find_package(OpenMP REQUIRED)
@@ -22,11 +21,19 @@ if(NOT TARGET OpenMP::OpenMP_CXX)
     add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
     set_property(TARGET OpenMP::OpenMP_CXX
                  PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
-    # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
     set_property(TARGET OpenMP::OpenMP_CXX
                  PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
 endif()
 
+find_package(Eigen3 REQUIRED NO_MODULE)
+if(NOT TARGET Eigen3::Eigen)
+    find_package(Threads REQUIRED)
+    add_library(Eigen3::Eigen IMPORTED INTERFACE)
+    set_property(TARGET Eigen3::Eigen
+                 PROPERTY INTERFACE_COMPILE_DEFINITIONS ${EIGEN3_DEFINITIONS})
+    set_property(TARGET Eigen3::Eigen
+                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIRS})
+endif()
 
 # Core CUDA Library for depth image processing
 add_library(${PROJECT_NAME} SHARED

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -70,6 +70,7 @@ target_include_directories(${PROJECT_NAME}_frontend PUBLIC
   "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_frontend SYSTEM PUBLIC
   ${PCL_INCLUDE_DIRS})
+target_compile_definitions(${PROJECT_NAME}_frontend PUBLIC ${PCL_DEFINITIONS})
 target_link_libraries(${PROJECT_NAME}_frontend PUBLIC
   ${PROJECT_NAME}
   ${PCL_LIBRARIES}
@@ -85,6 +86,7 @@ target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
   "$<INSTALL_INTERFACE:include>")
 target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
   ${PCL_INCLUDE_DIRS})
+target_compile_definitions(${PROJECT_NAME}_marching_cubes PUBLIC ${PCL_DEFINITIONS})
 target_link_libraries(${PROJECT_NAME}_marching_cubes PUBLIC
   ${PROJECT_NAME}
   ${PCL_LIBRARIES}
@@ -139,4 +141,3 @@ install(FILES
 
 export(EXPORT ${PROJECT_NAME}-targets FILE
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-targets.cmake)
-

--- a/yak/cmake/yak-config.cmake.in
+++ b/yak/cmake/yak-config.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+
+include(CMakeFindDependencyMacro)
+find_dependency(Eigen3)
+find_dependency(OpenMP)
+find_dependency(CUDA)
+find_dependency(OpenCV)
+find_dependency(PCL)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/yak/cmake/yak-config.cmake.in
+++ b/yak/cmake/yak-config.cmake.in
@@ -1,14 +1,28 @@
 @PACKAGE_INIT@
 
-set(@PROJECT_NAME@_FOUND ON)
-set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
-
 include(CMakeFindDependencyMacro)
 find_dependency(Eigen3)
+if(NOT TARGET Eigen3::Eigen)
+    find_package(Threads REQUIRED)
+    add_library(Eigen3::Eigen IMPORTED INTERFACE)
+    set_property(TARGET Eigen3::Eigen
+                 PROPERTY INTERFACE_COMPILE_DEFINITIONS ${EIGEN3_DEFINITIONS})
+    set_property(TARGET Eigen3::Eigen
+                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${EIGEN3_INCLUDE_DIRS})
+endif()
+
 find_dependency(OpenMP)
-find_dependency(CUDA)
-find_dependency(OpenCV)
-find_dependency(PCL)
+if(NOT TARGET OpenMP::OpenMP_CXX)
+    find_package(Threads REQUIRED)
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+endif()
+
+find_dependency(CUDA 9.0)
+find_dependency(OpenCV 3)
+find_dependency(PCL 1.8)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/yak/package.xml
+++ b/yak/package.xml
@@ -1,23 +1,20 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>yak</name>
-  <version>0.1.0</version>
-  <description>A truncated signed distance field(TSDF) to mesh tool</description>
+  <version>0.2.0</version>
+  <description>A library for working with Truncated Signed Distance Fields (TSDFs).</description>
   <author email="Joseph.Schornak@SwRI.org">Joseph Schornak</author>
   <author>Jonathan Meyer</author>
   <maintainer email="Joseph.Schornak@SwRI.org">Joseph Schornak</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
-
   <depend>libpcl-all-dev</depend>
   <depend>OpenMP</depend>
   <depend>Eigen3</depend>
+  <depend>CUDA</depend>
+  <depend>OpenCV</depend>
 
   <export>
-    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
-    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
-
 </package>


### PR DESCRIPTION
Make Yak a ROS-independent pure-CMake package. Add exported targets for libraries (yak::yak, yak::yak_frontend, yak::yak_marching_cubes). Use new CMake support for CUDA as a language: I think this means that the old CUDA target flag macros are no longer needed.

The PCL version requirement is reduced back to PCL 1.8. I'd originally bumped it up to 1.9 because I was having some CMake flag issues but I think the underlying problem was fixed on PCL's end.

The minimum CMake version for this is 3.10, which might impair compatibility with Ubuntu 16.04 and ROS Kinetic.

@Levi-Armstrong , could you take a look at this when you get a chance?