### PR TITLE
Fixes for Ubuntu 16.04 and CMake 3.5

### DIFF
--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -73,6 +73,11 @@ set_directory_properties( PROPERTIES COMPILE_DEFINITIONS "" )
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
+if(${CMAKE_VERSION} VERSION_LESS "3.9.0")
+  message(WARNING "You are using CMake version ${CMAKE_VERSION}. Consider upgrading!")
+  include_directories(include)  # TODO: Avoid using include_directories at all!
+endif()
+
 if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
     # Build for ROS 1 using Catkin
      find_package(catkin)
@@ -98,7 +103,6 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          OpenCV
          EIGEN3
          CUDA
-         OpenMP
          PCL
    )
 else()
@@ -190,7 +194,7 @@ target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
 target_link_libraries(${PROJECT_NAME}_marching_cubes
     PUBLIC
   ${PROJECT_NAME}
-  OpenMP::OpenMP_CXX
+  ${OpenMP_CXX_LIBRARIES}
 )
 
 # Jmeyer Marching Cubes

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -54,6 +54,15 @@ message(STATUS "CMAKE MODULE PATH IS ${CMAKE_MODULE_PATH}")
 
 find_package(OpenMP REQUIRED)
 
+if(NOT TARGET OpenMP::OpenMP_CXX)
+    find_package(Threads REQUIRED)
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+endif()
+
 find_package(CUDA REQUIRED)
 
 if (CUDA_VERSION_MAJOR GREATER 8)
@@ -97,7 +106,7 @@ if ($ENV{ROS_VERSION} VERSION_EQUAL "1")
          ${CUDA_LIBRARIES}
          ${CUDA_CUDA_LIBRARY}
          ${OpenCV_LIBS}
-         ${OpenMP_CXX_LIBRARIES}
+         OpenMP::OpenMP_CXX
        CATKIN_DEPENDS
        DEPENDS
          OpenCV
@@ -194,7 +203,7 @@ target_include_directories(${PROJECT_NAME}_marching_cubes PUBLIC
 target_link_libraries(${PROJECT_NAME}_marching_cubes
     PUBLIC
   ${PROJECT_NAME}
-  ${OpenMP_CXX_LIBRARIES}
+  OpenMP::OpenMP_CXX
 )
 
 # Jmeyer Marching Cubes


### PR DESCRIPTION
These changes are sort of contrary to the spirit of #3 , but they may be neded to support systems running Ubuntu 16.04 with CMake 3.5.

- Remove imported OpenMP targets, since [versions of CMake older than 3.9 don't generate them](https://stackoverflow.com/questions/12399422/how-to-set-linker-flags-for-openmp-in-cmakes-try-compile-function).
- Use old-style `include_directories()` function if a version of CMake older than 3.9 is detected.