### PR TITLE
Correct rosdep names in package.xml for eigne and opencv

### DIFF
--- a/yak/package.xml
+++ b/yak/package.xml
@@ -10,9 +10,9 @@
 
   <depend>libpcl-all-dev</depend>
   <depend>OpenMP</depend>
-  <depend>Eigen3</depend>
+  <depend>eigen</depend>
   <depend>CUDA</depend>
-  <depend>OpenCV</depend>
+  <depend>libopencv-dev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
This corrects the names for dependencies eigen and opencv to match [rosdep keys](https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml)