### PR TITLE
Remove depend on OpenMP and rename cuda depend to match rosdep key

### DIFF
--- a/yak/package.xml
+++ b/yak/package.xml
@@ -9,9 +9,8 @@
   <license>MIT</license>
 
   <depend>libpcl-all-dev</depend>
-  <depend>OpenMP</depend>
   <depend>eigen</depend>
-  <depend>CUDA</depend>
+  <depend>nvidia-cuda-dev</depend>
   <depend>libopencv-dev</depend>
 
   <export>


### PR DESCRIPTION
It looks like OpenMP does not have a key in rosdep, but I expect this is because it is a compiler feature not something you install through apt-get.