### PR TITLE
Fixes for CUDA 10.1 - remove obsolete any and ballot

### DIFF
--- a/yak/include/yak/kfusion/cuda/temp_utils.hpp
+++ b/yak/include/yak/kfusion/cuda/temp_utils.hpp
@@ -670,7 +670,7 @@ struct Emulation
   {
 #if __CUDA_ARCH__ >= 200
     (void)cta_buffer;
-    return __ballot(predicate);
+    return __ballot_sync(0xFFFFFFFF, predicate);
 #else
     int tid = Block::flattenedThreadId();
     cta_buffer[tid] = predicate ? (1 << (tid & 31)) : 0;
@@ -682,7 +682,7 @@ struct Emulation
   {
 #if __CUDA_ARCH__ >= 200
     (void)cta_buffer;
-    return __all(predicate);
+    return __all_sync(0xFFFFFFFF, predicate);
 #else
     int tid = Block::flattenedThreadId();
     cta_buffer[tid] = predicate ? 1 : 0;

--- a/yak/src/cuda/tsdf_volume.cu
+++ b/yak/src/cuda/tsdf_volume.cu
@@ -498,7 +498,7 @@ namespace kfusion
 #endif
 
 #if __CUDA_ARCH__ >= 120
-                    if (__all (x >= volume.dims.x) || __all (y >= volume.dims.y))
+                    if (__all_sync(0xFFFFFFFF, x >= volume.dims.x) || __all_sync(0xFFFFFFFF, y >= volume.dims.y))
                     return;
 #else
                     if (Emulation::All(x >= volume.dims.x, cta_buffer) || Emulation::All(y >= volume.dims.y, cta_buffer))
@@ -595,7 +595,7 @@ namespace kfusion
 
 #if __CUDA_ARCH__ >= 200
                         ///not we fulfilled points array at current iteration
-                        int total_warp = __popc (__ballot (local_count > 0)) + __popc (__ballot (local_count > 1)) + __popc (__ballot (local_count > 2));
+                        int total_warp = __popc (__ballot_sync(0xFFFFFFFF, local_count > 0)) + __popc (__ballot_sync(0xFFFFFFFF, local_count > 1)) + __popc (__ballot_sync(0xFFFFFFFF, local_count > 2));
 #else
                         int tid = Block::flattenedThreadId();
                         cta_buffer[tid] = local_count;


### PR DESCRIPTION
All those deprecated function warnings that we just ignored because they were just warnings? Those are now errors in CUDA 10.1. This pull request fixes them. I just copied the fixes [from PCL](https://github.com/scottmudge/pcl/commit/9e24e98ddc87d2dc62915fbdb8f966882d81f793), but I ran the bunny demo in yak_ros and it does work.