### PR TITLE
Added OpenMP dependency to package.xml

### DIFF
--- a/yak/package.xml
+++ b/yak/package.xml
@@ -12,6 +12,7 @@
   <depend>eigen</depend>
   <depend>nvidia-cuda-dev</depend>
   <depend>libopencv-dev</depend>
+  <depend>libomp-dev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
In the `README.md` the dependencies of `yak` are listed. In the `package.xml` all dependencies except the OpenMP library are listed, which will result in `rosdep install` not installing the library if I am correct. 

I've committed a change to `package.xml` to add the missing dependency. 

