### PR TITLE
Allow user to resize debug output window

### DIFF
--- a/yak/src/yak_server.cpp
+++ b/yak/src/yak_server.cpp
@@ -7,8 +7,9 @@ yak::FusionServer::FusionServer(const kfusion::KinFuParams& params, const Eigen:
   , last_camera_pose_(Eigen::Affine3f::Identity())
 {
   // Debug displays
-  cv::namedWindow("output");
-  cv::moveWindow("output", 10, 600);
+  cv::namedWindow("output", CV_WINDOW_NORMAL);
+  cv::moveWindow("output", 10, 10);
+  cv::resizeWindow("output", kinfu_->params().cols * 2, kinfu_->params().rows);
 }
 
 bool yak::FusionServer::fuse(const cv::Mat& depth_data, const Eigen::Affine3f& world_to_camera)


### PR DESCRIPTION
Implements #28.

Use `CV_WINDOW_NORMAL` flag to allow the user to resize the debug output OpenCV window after it's created.

There was an intermittent issue with the window being created with the wrong resolution, so the window is now resized to the correct initial dimensions after being initialized.