### PR TITLE
Remove volume_x assertion

### DIFF
--- a/yak/src/kfusion/kinfu.cpp
+++ b/yak/src/kfusion/kinfu.cpp
@@ -49,8 +49,6 @@ kfusion::KinFuParams kfusion::KinFuParams::default_params()
 
 kfusion::KinFu::KinFu(const KinFuParams& params) : frame_counter_(0), params_(params)
 {
-  CV_Assert(params.volume_dims[0] % 32 == 0);
-
   volume_ = cv::Ptr<cuda::TsdfVolume>(new cuda::TsdfVolume(params_.volume_dims));
 
   volume_->setTruncDist(params_.tsdf_trunc_dist);


### PR DESCRIPTION
PR to remove the `CV_Assert` in `kinfu.cpp`, see #33.

The assert checks if the `volume_x` dimension is a multiple of 32 for assignment of the volume to CUDA blocks/threads. As the CUDA code has thread checks in place, this assert should not be needed and can be removed. 

I tested the code by running the demo before and after the change with `volume_x = 640` and `volume_x = 641`, which seems to work as expected. 