### PR TITLE
Fix marching cubes not meshing voxels with few observations

### DIFF
--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -39,7 +39,7 @@ std::vector<Triangle> processCube(const yak::TSDFContainer& grid, int x, int y, 
     return 5.0f * float(f);
   };
 
-  const static uint16_t min_weight = 4;
+  const static uint16_t min_weight = 1;
 
   uint16_t w;
   val[0] = read(x + 1, y + 1, z, w);


### PR DESCRIPTION
Fixes #38 

Sets the minimum voxel weight to `1` when processing the TSDF volume with marching cubes, which means that if a voxel has been observed at least once it'll get meshed.