### PR TITLE
Parameterize minimum voxel weight of marching cubes

### DIFF
--- a/yak/include/yak/mc/marching_cubes.h
+++ b/yak/include/yak/mc/marching_cubes.h
@@ -11,6 +11,9 @@ struct MarchingCubesParameters
   // Scale factor applied to vertices. Usually equal to physical size of a single
   // voxel element.
   double scale = 1.0;
+
+  // Minimum weight of a voxel to not be dropped in the meshing process.
+  int min_weight = 4;
 };
 
 pcl::PolygonMesh marchingCubesCPU(const yak::TSDFContainer& tsdf, const MarchingCubesParameters& params = {});

--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -39,7 +39,7 @@ std::vector<Triangle> processCube(const yak::TSDFContainer& grid, int x, int y, 
     return 5.0f * float(f);
   };
 
-  const static uint16_t min_weight = 4;
+  const static uint16_t min_weight = 1;
 
   uint16_t w;
   val[0] = read(x + 1, y + 1, z, w);

--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -29,7 +29,7 @@ const static int cubeOffsets[8][3] = {
   { 1, 1, 1 }, { 1, 0, 1 }, { 0, 0, 1 }, { 0, 1, 1 },
 };
 
-std::vector<Triangle> processCube(const yak::TSDFContainer& grid, int x, int y, int z)
+std::vector<Triangle> processCube(const yak::TSDFContainer& grid, int x, int y, int z, int min_weight)
 {
   // Copy the isovalues of the nearby surfaces into a local array
   float val[8];
@@ -38,8 +38,6 @@ std::vector<Triangle> processCube(const yak::TSDFContainer& grid, int x, int y, 
     grid.read(grid.toIndex(x, y, z), f, w);
     return 5.0f * float(f);
   };
-
-  const static uint16_t min_weight = 1;
 
   uint16_t w;
   val[0] = read(x + 1, y + 1, z, w);
@@ -164,7 +162,7 @@ pcl::PolygonMesh makeMesh(const yak::TSDFContainer& grid, const yak::MarchingCub
     {
       for (int z = 1; z < grid.dims().z(); ++z)
       {
-        std::vector<Triangle> ts = processCube(grid, x - 1, y - 1, z - 1);
+        std::vector<Triangle> ts = processCube(grid, x - 1, y - 1, z - 1, params.min_weight);
         triangle_buffers[tid].insert(triangle_buffers[tid].end(), ts.begin(), ts.end());
       }
     }


### PR DESCRIPTION
This parameterizes the minimum voxel weight of the marching cubes step of the mesh generation. In turn, this allows us to tune the behavior based on the number of observations available. Defaults to `4` so current behavior is not affected. 

Based on #39 and should fix #38.

