### PR TITLE
Add clang-format job to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,10 @@ jobs:
              OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,
-             ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
              BADGE: bionic,
              CLANG_FORMAT_CHECK: file,
              CLANG_FORMAT_VERSION: 8,
-             DOCKER_PULL: false,
-             DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda10.2"}
+             }
           - {OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,16 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - {CI_NAME: clang-format,
+             OS_NAME: ubuntu,
+             OS_CODE_NAME: bionic,
+             ROS_DISTRO: melodic,
+             ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
+             BADGE: bionic,
+             CLANG_FORMAT_CHECK: file,
+             CLANG_FORMAT_VERSION: 8,
+             DOCKER_PULL: false,
+             DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda10.2"}
           - {OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,

--- a/yak/src/kfusion/tsdf_volume.cpp
+++ b/yak/src/kfusion/tsdf_volume.cpp
@@ -92,10 +92,10 @@ void kfusion::cuda::TsdfVolume::integrate(const Dists& dists, const Affine3f& ca
   // actual transform from the camera to the center of the volume What does this even do, exactly? As written it's
   // calculating the new transform from the frame of the volume to the frame of the camera after applying the motion of
   // the most recent measurement.
-//  std::cout << "CAMERA MOTION TFORM:\n" << camera_motion_tform.inv().matrix << "\n";
+  //  std::cout << "CAMERA MOTION TFORM:\n" << camera_motion_tform.inv().matrix << "\n";
   //    std::cout << "POSE_\n" << pose_.matrix << "\n";
   Affine3f vol2cam = camera_motion_tform.inv() * pose_;
-//  std::cout << "vol2cam:\n" << vol2cam.matrix << "\n";
+  //  std::cout << "vol2cam:\n" << vol2cam.matrix << "\n";
   device::Projector proj(intr.fx, intr.fy, intr.cx, intr.cy);
   //    printf("Intr: %f %f %f %f\n", intr.fx, intr.fy, intr.cx, intr.cy);
 

--- a/yak/src/yak_server.cpp
+++ b/yak/src/yak_server.cpp
@@ -1,5 +1,5 @@
 #include <yak/yak_server.h>
-#include <opencv2/highgui/highgui.hpp> // named-window apparatus; TODO: Remove this
+#include <opencv2/highgui/highgui.hpp>  // named-window apparatus; TODO: Remove this
 
 yak::FusionServer::FusionServer(const kfusion::KinFuParams& params, const Eigen::Affine3f& world_to_volume)
   : kinfu_(new kfusion::KinFu(params))


### PR DESCRIPTION
- Implements #43: adds a CI job that checks against the style defined in the existing `.clang-format` file.
- Fix some spacing issues that were causing the new clang-format job to fail.