### PR TITLE
Support setting cuda arch and improve mesh generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   industrial_ci:
+    name: ${{ matrix.env.CI_NAME }}
     strategy:
       fail-fast: false
       matrix:
@@ -13,9 +19,9 @@ jobs:
              ROS_DISTRO: melodic,
              BADGE: bionic,
              CLANG_FORMAT_CHECK: file,
-             CLANG_FORMAT_VERSION: 8,
-             }
-          - {OS_NAME: ubuntu,
+             CLANG_FORMAT_VERSION: 8}
+          - {CI_NAME: Melodic-Cuda10.2,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,
              ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
@@ -23,7 +29,8 @@ jobs:
              TARGET_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
              DOCKER_PULL: false,
              DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda10.2"}
-          - {OS_NAME: ubuntu,
+          - {CI_NAME: Melodic-Cuda9.2,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: bionic,
              ROS_DISTRO: melodic,
              ROSDEP_SKIP_KEYS: nvidia-cuda-dev,
@@ -31,7 +38,8 @@ jobs:
              TARGET_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
              DOCKER_PULL: false,
              DOCKER_IMAGE: "schornakj/yak_ci:bionic-cuda9.2"}
-          - {OS_NAME: ubuntu,
+          - {CI_NAME: Xenial-Cuda10.2,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: xenial,
              ROS_DISTRO: kinetic,
              ROSDEP_SKIP_KEYS: nvidia-cuda-dev libpcl-all-dev,
@@ -39,7 +47,8 @@ jobs:
              TARGET_CMAKE_ARGS: "-DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs/",
              DOCKER_PULL: false,
              DOCKER_IMAGE: "schornakj/yak-1:xenial-cuda10.2"}
-          - {OS_NAME: ubuntu,
+          - {CI_NAME: Kinetic-Cuda9.2,
+             OS_NAME: ubuntu,
              OS_CODE_NAME: xenial,
              ROS_DISTRO: kinetic,
              ROSDEP_SKIP_KEYS: nvidia-cuda-dev libpcl-all-dev,
@@ -49,6 +58,6 @@ jobs:
              DOCKER_IMAGE: "schornakj/yak-1:xenial-cuda9.2"}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}

--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 find_package(CUDA 9.0 REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui)
-find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry)
+find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry surface)
 
 find_package(OpenMP REQUIRED)
 if(NOT TARGET OpenMP::OpenMP_CXX)
@@ -54,7 +54,12 @@ macro(target_add_options_and_definitions TARGET)
   endforeach()
 endmacro()
 
-CUDA_SELECT_NVCC_ARCH_FLAGS(ARCH_FLAGS Auto)
+if (NOT DEFINED CUDA_ARCH_AND_PTX)
+  CUDA_SELECT_NVCC_ARCH_FLAGS(ARCH_FLAGS Auto)
+else()
+  CUDA_SELECT_NVCC_ARCH_FLAGS(ARCH_FLAGS ${CUDA_ARCH_AND_PTX})
+endif()
+
 LIST(APPEND CUDA_NVCC_FLAGS ${ARCH_FLAGS})
 list(APPEND CUDA_NVCC_FLAGS "--compiler-options -fPIC")
 

--- a/yak/include/yak/mc/marching_cubes.h
+++ b/yak/include/yak/mc/marching_cubes.h
@@ -10,10 +10,13 @@ struct MarchingCubesParameters
 {
   // Scale factor applied to vertices. Usually equal to physical size of a single
   // voxel element.
-  double scale = 1.0;
+  double scale{ 1.0 };
 
   // Minimum weight of a voxel to not be dropped in the meshing process.
-  int min_weight = 4;
+  int min_weight{ 4 };
+
+  // Clean the produced mesh by removing duplicate vertices, zero area triangles, etc.
+  bool clean{ false };
 };
 
 pcl::PolygonMesh marchingCubesCPU(const yak::TSDFContainer& tsdf, const MarchingCubesParameters& params = {});


### PR DESCRIPTION
Currently the marching cubes mesher return duplicate vertices, zero area triangles ext. This uses vtk directly to populate the mesh from the algorithm then leverages the vtk clean poly data to clean up the mesh.