### PR TITLE
Fix incorrect mesh size during marching-cubes meshing

### DIFF
--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -159,7 +159,7 @@ pcl::PolygonMesh makeMesh(const yak::TSDFContainer& grid, const yak::MarchingCub
 {
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
   vtkSmartPointer<vtkCellArray> triangles = vtkSmartPointer<vtkCellArray>::New();
-
+  double s = params.scale;
 #pragma omp parallel for
   for (int x = 1; x < grid.dims().x(); ++x)
   {
@@ -173,11 +173,11 @@ pcl::PolygonMesh makeMesh(const yak::TSDFContainer& grid, const yak::MarchingCub
           for (auto& t : ts)
           {
             vtkIdType p1 = points->InsertNextPoint(
-                static_cast<double>(t.v[0].x()), static_cast<double>(t.v[0].y()), static_cast<double>(t.v[0].z()));
+                s*static_cast<double>(t.v[0].x()), s*static_cast<double>(t.v[0].y()), s*static_cast<double>(t.v[0].z()));
             vtkIdType p2 = points->InsertNextPoint(
-                static_cast<double>(t.v[1].x()), static_cast<double>(t.v[1].y()), static_cast<double>(t.v[1].z()));
+                s*static_cast<double>(t.v[1].x()), s*static_cast<double>(t.v[1].y()), s*static_cast<double>(t.v[1].z()));
             vtkIdType p3 = points->InsertNextPoint(
-                static_cast<double>(t.v[2].x()), static_cast<double>(t.v[2].y()), static_cast<double>(t.v[2].z()));
+                s*static_cast<double>(t.v[2].x()), s*static_cast<double>(t.v[2].y()), s*static_cast<double>(t.v[2].z()));
 
             vtkSmartPointer<vtkTriangle> triangle = vtkSmartPointer<vtkTriangle>::New();
             triangle->GetPointIds()->SetId(0, p1);

--- a/yak/src/mc/marching_cubes.cpp
+++ b/yak/src/mc/marching_cubes.cpp
@@ -172,12 +172,15 @@ pcl::PolygonMesh makeMesh(const yak::TSDFContainer& grid, const yak::MarchingCub
         {
           for (auto& t : ts)
           {
-            vtkIdType p1 = points->InsertNextPoint(
-                s*static_cast<double>(t.v[0].x()), s*static_cast<double>(t.v[0].y()), s*static_cast<double>(t.v[0].z()));
-            vtkIdType p2 = points->InsertNextPoint(
-                s*static_cast<double>(t.v[1].x()), s*static_cast<double>(t.v[1].y()), s*static_cast<double>(t.v[1].z()));
-            vtkIdType p3 = points->InsertNextPoint(
-                s*static_cast<double>(t.v[2].x()), s*static_cast<double>(t.v[2].y()), s*static_cast<double>(t.v[2].z()));
+            vtkIdType p1 = points->InsertNextPoint(s * static_cast<double>(t.v[0].x()),
+                                                   s * static_cast<double>(t.v[0].y()),
+                                                   s * static_cast<double>(t.v[0].z()));
+            vtkIdType p2 = points->InsertNextPoint(s * static_cast<double>(t.v[1].x()),
+                                                   s * static_cast<double>(t.v[1].y()),
+                                                   s * static_cast<double>(t.v[1].z()));
+            vtkIdType p3 = points->InsertNextPoint(s * static_cast<double>(t.v[2].x()),
+                                                   s * static_cast<double>(t.v[2].y()),
+                                                   s * static_cast<double>(t.v[2].z()));
 
             vtkSmartPointer<vtkTriangle> triangle = vtkSmartPointer<vtkTriangle>::New();
             triangle->GetPointIds()->SetId(0, p1);


### PR DESCRIPTION
This is a change provided by @drchrislewis in #59 with clang-format applied so that CI can succeed.

The changes made in #58 left out the marching cubes `scale` parameter, which converts the mesh from units of voxel indices to units of meters. This fixes that by applying the `scale` parameter when creating new vertices.