### PR TITLE
WIP: Volume Config

### DIFF
--- a/yak/CMakeLists.txt
+++ b/yak/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED CMAKE_CUDA_STANDARD)
   set(CMAKE_CUDA_STANDARD_REQUIRED True)
 endif()
 
-find_package(cmake_common_scripts REQUIRED)
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
 find_package(CUDA 9.0 REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui)
 find_package(PCL 1.8 REQUIRED COMPONENTS common io geometry surface)
@@ -150,7 +150,7 @@ target_link_libraries(marching_cubes_tests
 install(DIRECTORY include/${PROJECT_NAME}
   DESTINATION include)
 
-# cmake_common_scripts package configure
+# ros_industrial_cmake_boilerplate package configure
 configure_package(NAMESPACE yak TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_frontend ${PROJECT_NAME}_marching_cubes)
 
 # uninstall target

--- a/yak/package.xml
+++ b/yak/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="Joseph.Schornak@SwRI.org">Joseph Schornak</maintainer>
   <license>MIT</license>
 
-  <build_depend>cmake_common_scripts</build_depend>
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
 
   <depend>libpcl-all-dev</depend>
   <depend>eigen</depend>

--- a/yak/src/kfusion/kinfu.cpp
+++ b/yak/src/kfusion/kinfu.cpp
@@ -59,7 +59,8 @@ kfusion::KinFu::KinFu(const KinFuParams& params) : frame_counter_(0), params_(pa
                    params_.volume_dims[1] * params_.volume_resolution,
                    params_.volume_dims[2] * params_.volume_resolution);
   volume_->setSize(volumeSize);
-  //    volume_->setPose(params_.volume_pose);
+  //This is not enough to translate the actual volume; still @ world 0
+  //volume_->setPose(params_.volume_pose);
 
   volume_->setRaycastStepFactor(params_.raycast_step_factor);
   volume_->setGradientDeltaFactor(params_.gradient_delta_factor);
@@ -76,7 +77,7 @@ kfusion::KinFu::KinFu(const KinFuParams& params) : frame_counter_(0), params_(pa
   poses_.reserve(30000);
 
   // TODO: Allow loading of robot pose instead of default volume pose
-  poses_.push_back(params_.volume_pose.matrix);
+  poses_.push_back(params_.volume_pose);
 }
 
 const kfusion::KinFuParams& kfusion::KinFu::params() const { return params_; }
@@ -139,7 +140,7 @@ void kfusion::KinFu::resetPose()
   poses_.reserve(30000);
 
   // TODO: Allow loading of robot pose instead of default volume pose
-  poses_.push_back(params_.volume_pose.matrix);
+  poses_.push_back(params_.volume_pose);
   cout << "Resetting to: " << params_.volume_pose.matrix << endl;
 
   //    volume_->clear();

--- a/yak/src/yak_server.cpp
+++ b/yak/src/yak_server.cpp
@@ -1,4 +1,5 @@
 #include <yak/yak_server.h>
+#include <opencv2/core/eigen.hpp>
 #include <opencv2/highgui/highgui.hpp>  // named-window apparatus; TODO: Remove this
 
 yak::FusionServer::FusionServer(const kfusion::KinFuParams& params, const Eigen::Affine3f& world_to_volume)
@@ -47,6 +48,7 @@ bool yak::FusionServer::reset()
 bool yak::FusionServer::resetWithNewParams(const kfusion::KinFuParams& params)
 {
   kinfu_.reset(new kfusion::KinFu(params));
+  cv::cv2eigen(params.volume_pose.inv().matrix, volume_to_world_.matrix());
   return true;
 }
 

--- a/yak_ext/CMakeLists.txt
+++ b/yak_ext/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(yak_ext VERSION 0.1.0)
 
-find_package(cmake_common_scripts REQUIRED)
+find_package(ros_industrial_cmake_boilerplate REQUIRED)
 
 if(BUILD_TESTING)
   find_package(GTest QUIET)

--- a/yak_ext/package.xml
+++ b/yak_ext/package.xml
@@ -6,7 +6,7 @@
   <maintainer email="joseph.schornak@swri.org">Joseph Schornak</maintainer>
   <author email="joseph.schornak@swri.org">Joseph Schornak</author>
   <license>Apache 2.0</license>
-  <build_depend>cmake_common_scripts</build_depend>
+  <build_depend>ros_industrial_cmake_boilerplate</build_depend>
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
The PR adds the ability to move the TSDF volume without needing a new tf frame. Goes with https://github.com/ros-industrial/yak_ros/pull/51 in yak_ros