### PR TITLE
Add attribution statement to README and fix out-of-date info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,29 @@
 
 Yak is a library for integrating depth images into Truncated Signed Distance Fields (TSDFs). It is currently supported for Ubuntu 16.04 and Ubuntu 18.04. An example ROS node using Yak is provided in the [yak_ros](https://github.com/ros-industrial/yak_ros) repository.
 
+A ROS interface is provided at [`yak_ros`](https://github.com/ros-industrial/yak_ros), and a ROS2 interface is provided at [`yak_ros2`](https://github.com/ros-industrial/yak_ros2);
+
+## Attribution
+
+This library was originally a fork of [`personalrobotics/kinfu_ros`](https://github.com/personalrobotics/kinfu_ros), and the underlying TSDF algorithm is very similar to the implementation used there.
+
 ## Technical Background
 
-A TSDF is a probabilistic representation of a solid surface in 3D space. It's a useful tool for combining many noisy incomplete sensor readings into a single smooth and complete model.
+A TSDF is a probabilistic representation of a solid surface in 3D space. It is a useful tool for combining many noisy incomplete sensor readings into a single smooth and complete model.
 
 To break down the name:
 
-Distance Field: Each voxel in the volume contains a value that represents its metric distance from the closest point on the surface. Voxels very far from the surface have high-magnitude distance values, while those near the surface have values approaching zero.
+- Distance Field: Each voxel in the volume contains a value that represents its metric distance from the closest point on the surface. Voxels very far from the surface have high-magnitude distance values, while those near the surface have values approaching zero.
 
-Signed: Voxels outside the surface have positive distances, while voxels inside the surface have negative distances. This allows the representation of solid objects. The distance field represents a gradient that shifts from positive to negative as it crosses the surface.
+- Signed: Voxels outside the surface have positive distances, while voxels inside the surface have negative distances. This allows the representation of solid objects. The distance field represents a gradient that shifts from positive to negative as it crosses the surface.
 
-Truncated: Voxels further than a specified distance from the isosurface have their values capped at +/- 1 because we are only interested in precisely representing the region of the volume close to solid objects.
+- Truncated: Voxels further than a specified distance from the isosurface have their values capped at +/- 1 because we are only interested in precisely representing the region of the volume close to solid objects.
 
 The TSDF algorithm can be efficiently parallelized on a general-purpose graphics processor, which allows data from RGB-D cameras to be integrated into the volume in real time. Numerous observations of an object from different perspectives average out noise and errors due to specular highlights and interreflections, producing a smooth continuous surface. This is a key advantage over equivalent point-cloud-centric strategies, which require additional processing to distinguish between engineered features and erroneous artifacts in the scan data. The volume can be converted to a triangular mesh using the Marching Cubes algorithm for consumption by application-specific processes.
 
-Yak is intended as a flexible library that gives the end user (you!) a lot of freedom over when data gets integrated, which poses are used, whether Iterative Closest Point plays a role, etc.
+### Example Output
+
+The picture below shows a mode of an aluminum part that was reconstructed using the TSDF algorithm and meshed using the Marching Cubes algorithm.
 
 ![An aluminum part reconstructed as a TSDF and meshed with the Marching Cubes algorithm.](/aluminum_channel_mesh.png)
 
@@ -36,7 +44,7 @@ Yak requires CMake 3.10.0 or newer in order to take advantage of improved suppor
 sudo apt install python-pip
 ```
 
-2. Use pip to install CMake locally, which will not overwrite the system installation of CMake. As of September 5 2019 this installs CMake 3.14.4 on Ubuntu 16.04.
+2. Use pip to install a newer version of CMake locally, which will not overwrite the system installation of CMake.
 ```
 pip install --user cmake --upgrade
 ```
@@ -63,10 +71,14 @@ driver   : nvidia-driver-390 - distro non-free
 driver   : xserver-xorg-video-nouveau - distro free builtin
 ```
 
-2. Consult the chart below (copied from [here](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver) as of September 5 2019) to find which CUDA version is compatible with the drivers supported by your GPU. Yak is currently not compatible with CUDA <= 8.0.
+2. Consult the chart below (copied from [here](https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver) as of Februray 13 2021) to find which CUDA version is compatible with the drivers supported by your GPU. **Yak is currently not compatible with CUDA <= 8.0**.
 
 | CUDA Toolkit | Linux x86_64 Driver Version |
 |---|---|
+| CUDA 11.2 | >= 450.80.02 |
+| CUDA 11.1 (11.1.0) | >= 450.80.02 |
+| CUDA 11.0 (11.0.3) | >= 450.36.06 |
+| CUDA 10.2 (10.2.89) | >= 440.33 |
 | CUDA 10.1 (10.1.105) | >= 418.39 |
 | CUDA 10.0 (10.0.130) | >= 410.48 | 
 | CUDA 9.2 (9.2.88) | >= 396.26 |
@@ -140,8 +152,6 @@ make
 sudo make install
 ```
 
-## Readme TODOs:
+## Examples
 
-- Minimally-functional example
-- Documentation of services, inputs, outputs, etc.
-
+[`yak_ros`](https://github.com/ros-industrial/yak_ros) and [`yak_ros2`](https://github.com/ros-industrial/yak_ros2) provide instructions for building and running ROS demo applications.


### PR DESCRIPTION
- Add a note about this project's original fork origin. I feel that it's important to emphasize that the Yak library is an incremental improvement on the previous body of KinectFusion-related work rather than a totally new algorithm.
- Update some out-of-date info about CUDA versions. In particular, include CUDA 11.0+.
- Add links to `yak_ros` and `yak_ros2` for demo applications.